### PR TITLE
Fixing the name that shows up in the header

### DIFF
--- a/app/views/partials/main.html
+++ b/app/views/partials/main.html
@@ -27,7 +27,7 @@
 </nav>
 
 <div class="panel panel-default diffs" ng-repeat="diff in diffs">
-    <div class="panel-heading"><h3 class="panel-title">{{ diff.split('.')[0] }}</h3></div>
+    <div class="panel-heading"><h3 class="panel-title">{{ diff.split('.')[1] }}</h3></div>
     <div class="panel-body">
         <imagediff diff="diff" project="dir" />
     </div>


### PR DESCRIPTION
Making the header show the name of the section instead of the page.
