### PR TITLE
Fixing image diffs from not appearing

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -105,10 +105,6 @@ imagediff {
     .panel-heading {
         background-color: #d9534f;
     }
-
-    img {
-        position: absolute;
-    }
 }
 .shots {
     .panel-heading {


### PR DESCRIPTION
Fixing image diffs not showing up because they were absolute positioned with no width
