### PR TITLE
Make repository dir configurable; fix image paths on acceptDiff

### DIFF
--- a/server/config/env/all.js
+++ b/server/config/env/all.js
@@ -7,6 +7,7 @@ var rootPath = path.normalize(__dirname + '/../../..');
 module.exports = {
     root: rootPath,
     ip: '0.0.0.0',
+    imageRepo: process.env.IMAGE_REPO || path.join(__dirname, '..', '..', '..', 'repositories'),
     port: process.env.PORT || 9000,
     mongo: {
         options: {

--- a/server/controllers/api.js
+++ b/server/controllers/api.js
@@ -182,9 +182,18 @@ exports.downloadRepository = function(req, res) {
 
 exports.acceptDiff = function(req, res) {
 
-    var newFile = req.body.file,
-        currentFile = newFile.replace('.new.png', '.baseline.png'),
-        diffFile = newFile.replace('.new.png', '.diff.png'),
+    /*
+    The angular.js code still expects the new file to be suffixed '.new.png',
+    but it's actually '.regression.png in the repository.
+
+    We'll deal with this by assuming the .new.png in the file requested by the
+    client is actually .regression.png
+    */
+
+    var imageName = req.body.file.split(".new.png")[0],
+        newFile = imageName + ".regression.png",
+        currentFile = imageName + ".baseline.png",
+        diffFile = imageName + ".diff.png",
         project = null,
         processed = 0;
 

--- a/server/controllers/api.js
+++ b/server/controllers/api.js
@@ -16,7 +16,7 @@ var fs = require('fs-extra'),
     targz = require('tar.gz'),
     async = require('async'),
     readDir = require('../utils/readDir'),
-    imageRepo = path.join(__dirname, '..', '..', '..', 'repositories');
+    config = require('../config/config');
 
 exports.syncImages = function(req, res) {
 
@@ -25,7 +25,7 @@ exports.syncImages = function(req, res) {
     }
 
     fs.readFile(req.files.gz.path, function(err, data) {
-        var newPath = path.join(imageRepo, req.files.gz.name);
+        var newPath = path.join(config.imageRepo, req.files.gz.name);
 
         fs.remove(newPath.replace(/\.tar\.gz/, ''), function(err) {
             if (err) {
@@ -37,7 +37,7 @@ exports.syncImages = function(req, res) {
                     throw (err);
                 }
 
-                new targz().extract(newPath, imageRepo);
+                new targz().extract(newPath, config.imageRepo);
                 res.send(200);
             });
 
@@ -48,7 +48,7 @@ exports.syncImages = function(req, res) {
 
 exports.getDirectoryList = function(req, res) {
 
-    readDir(imageRepo, function(err, list) {
+    readDir(config.imageRepo, function(err, list) {
         if (err) {
             throw err;
         }
@@ -66,7 +66,7 @@ exports.getImage = function(req, res) {
     /**
      * read directory to check if hash matches given files
      */
-    fs.readdir(imageRepo, function(err, files) {
+    fs.readdir(config.imageRepo, function(err, files) {
 
         if (err || files.length === 0) {
             return res.send(404);
@@ -94,9 +94,9 @@ exports.getImage = function(req, res) {
              * generate file path
              */
             if (req.params.file) {
-                filepath = path.join(imageRepo, file, req.params.file);
+                filepath = path.join(config.imageRepo, file, req.params.file);
             } else {
-                filepath = path.join(imageRepo, file, 'diff', req.params.diff);
+                filepath = path.join(config.imageRepo, file, 'diff', req.params.diff);
             }
 
             /**
@@ -121,7 +121,7 @@ exports.downloadRepository = function(req, res) {
         project = file.replace(/\.tar\.gz/, ''),
         tmpPath = path.join(__dirname, '..', '..', '.tmp', 'webdrivercss-adminpanel' , project),
         tarPath = tmpPath + '.tar.gz',
-        projectPath = path.join(imageRepo, project);
+        projectPath = path.join(config.imageRepo, project);
 
     /**
      * create tmp directory and create tarball to download on the fly
@@ -196,7 +196,7 @@ exports.acceptDiff = function(req, res) {
          * get uploads dir filestructure
          */
         function(done) {
-            return fs.readdir(imageRepo, done);
+            return fs.readdir(config.imageRepo, done);
         },
         /**
          * iterate through all files
@@ -233,8 +233,8 @@ exports.acceptDiff = function(req, res) {
 
             project = file;
 
-            var source = path.join(imageRepo, project, newFile),
-                dest = path.join(imageRepo, project, currentFile);
+            var source = path.join(config.imageRepo, project, newFile),
+                dest = path.join(config.imageRepo, project, currentFile);
 
             return fs.copy(source, dest, done);
 
@@ -243,13 +243,13 @@ exports.acceptDiff = function(req, res) {
          * remove obsolete new.png file
          */
         function(done) {
-            return fs.remove(path.join(imageRepo, project, newFile), done);
+            return fs.remove(path.join(config.imageRepo, project, newFile), done);
         },
         /**
          * remove diff file
          */
         function(done) {
-            return fs.remove(path.join(imageRepo, project, 'diff', diffFile), done);
+            return fs.remove(path.join(config.imageRepo, project, 'diff', diffFile), done);
         }
     ], function(err) {
 


### PR DESCRIPTION
Making the repository dir configurable with an environment variable makes a clean deploymemt easier: the directory with mutable data is separated from the server code.

The image paths were a bit of a confusing one - I can see some fixes for the change to `.regression.png` in the tree, but they don't seem to be complete. With the changes in 
04c8c23, everything works as expected for us in the adminpanel.
