### PR TITLE
Minor content updates

### DIFF
--- a/app/views/partials/main.html
+++ b/app/views/partials/main.html
@@ -34,7 +34,9 @@
 </div>
 
 <div class="panel panel-default shots" ng-repeat="shot in shots">
-    <div class="panel-heading"><h3 class="panel-title">{{ shot.split('.').slice(0,-1).join(' ') }}</h3></div>
+    <div class="panel-heading">
+        <h3 class="panel-title">{{ shot.split('.').slice(0,-1).join(' ') }}</h3>
+    </div>
     <div class="panel-body">
         <img ng-src="/api/repositories/{{ dir }}/{{ shot }}" alt="{{ shot }}">
     </div>
@@ -44,14 +46,16 @@
     <h2>Howdy,</h2>
 
     <p>
-        and congratulation! You've successfully set up the WebdriverCSS Adminpanel. Now you can start with
-        your CSS regression tests. This Application will help you to get an overview of all made screenshots
-        of your project.
+        …and congratulations!
+        You've successfully set up the WebdriverCSS Adminpanel.
+        Now you can start with your CSS regression tests.
+        This application will help you to get an overview
+        of all made screenshots of your project.
     </p>
 
     <p>
-        To get started just the type your project name into the input field and copy the source code below
-        into a test file and execute it.
+        To get started just type your project name into the input field and copy
+        the source code below into a test file and execute it.
     </p>
 
     <label for="projectname" style="margin-top: 20px;">Your Project Name</label>


### PR DESCRIPTION
Minor formatting, grammar and typo updates.
## Additions
- Adds ellipsis to beginning of first paragraph.
## Removals
- Removes extra `the`.
## Changes
- `congratulation` > `congratulations`. Both are fine AFAIK, but plural reads a bit better IMO.
- Semantic line breaks to under 80 characters for the copy.
- Breaks nested panel-title HTML across multiple lines.
- Lowercases `application`.
## Preview

![screen shot 2015-04-07 at 9 25 56 pm](https://cloud.githubusercontent.com/assets/704760/7037200/b55a435e-dd6c-11e4-9edc-e11151a828a4.png)
