### PR TITLE
Image filenames are not consistent with the repositories.

### DIFF
--- a/server/controllers/api.js
+++ b/server/controllers/api.js
@@ -182,9 +182,18 @@ exports.downloadRepository = function(req, res) {
 
 exports.acceptDiff = function(req, res) {
 
-    var newFile = req.body.file,
-        currentFile = newFile.replace('.new.png', '.baseline.png'),
-        diffFile = newFile.replace('.new.png', '.diff.png'),
+    /*
+    The angular.js code still expects the new file to be suffixed '.new.png',
+    but it's actually '.regression.png in the repository.
+
+    We'll deal with this by assuming the .new.png in the file requested by the
+    client is actually .regression.png
+    */
+
+    var imageName = req.body.file.split(".new.png")[0],
+        newFile = imageName + ".regression.png",
+        currentFile = imageName + ".baseline.png",
+        diffFile = imageName + ".diff.png",
         project = null,
         processed = 0;
 


### PR DESCRIPTION
This is a cherry pick of https://github.com/Learnosity/webdrivercss-adminpanel/commit/04c8c2323432c58699fdcde0743db2c57b497e0d from #15 

Tested this on my local install and seems to have resolved the issue.
## Original commit message:

I think there was some confusion with the work that went into
a778eb03e4d16d14b1abd4bf1e018d9282a262cf (pull request #7) - when
accepting diffs, it was still using the filename specified on the client
side that was suffixed '.new.png', but that file isn't part of the
tarball generated by WebDriverCSS.
