### PR TITLE
Use local bower install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,13 @@ colleagues to be able to run regression tests decentralized.
 - **NodeJS and npm**
   For installing packages.
   Download and run the [NodeJS installer](https://nodejs.org/download/).
-- **Bower**
-  For installing client-side dependencies.
-  Run `npm install -g bower`.
 - **Ruby, Sass, and Compass**
   Needed for Compass extension to SASS, which provides CSS niceties.
   Install [Ruby](https://www.ruby-lang.org/en/documentation/installation/)
   and run `gem install compass`.
 
-> Note: Grunt will be installed locally with npm.
-  If you'd like to install Grunt globally, run `npm install -g grunt-cli`.
+> Note: Grunt & Bower will be installed locally with npm.
+  If you'd like to install Grunt or Bower globally, run `npm install -g grunt-cli` or `npm install -g bower`, respectively.
 
 
 ## Install
@@ -37,7 +34,6 @@ Then download all client and server-side dependencies:
 
 ```sh
 $ npm install
-$ bower install
 ```
 
 Last but not least start the application by running:

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "tar.gz": "^0.1.1"
   },
   "devDependencies": {
-    "grunt-cli": "^0.1.13",
+    "bower": "1.5.2",
+    "connect-livereload": "~0.3.0",
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",
+    "grunt-cli": "^0.1.13",
     "grunt-concurrent": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-coffee": "~0.7.0",
@@ -36,27 +38,27 @@
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.2",
+    "grunt-env": "~0.4.1",
+    "grunt-express-server": "~0.4.5",
     "grunt-google-cdn": "~0.2.0",
     "grunt-newer": "~0.5.4",
     "grunt-ngmin": "~0.0.2",
+    "grunt-node-inspector": "~0.1.3",
+    "grunt-nodemon": "~0.2.0",
+    "grunt-open": "~0.2.0",
     "grunt-rev": "~0.1.0",
     "grunt-svgmin": "~0.2.0",
     "grunt-usemin": "~2.0.0",
     "jshint-stylish": "~0.1.3",
     "load-grunt-tasks": "~0.2.0",
-    "time-grunt": "~0.2.1",
-    "grunt-express-server": "~0.4.5",
-    "grunt-open": "~0.2.0",
-    "connect-livereload": "~0.3.0",
-    "grunt-env": "~0.4.1",
-    "grunt-node-inspector": "~0.1.3",
-    "grunt-nodemon": "~0.2.0",
-    "open": "~0.0.4"
+    "open": "~0.0.4",
+    "time-grunt": "~0.2.1"
   },
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
+    "postinstall": "bower install",
     "test": "grunt test",
     "start": "grunt serve:dist"
   }


### PR DESCRIPTION
This takes advantage of an NPM postinstall hook to run `bower install`, avoiding the need to globally install bower and making the install a step simpler. 
# Testing
- On a clean repo, run `npm install`.
- Validate that the console logs show `bower install` being run after the npm install step is complete. Validate all client-side resources are available. 
## Notes

The global bower install (if available) will work as always. This means installing new client side dependencies can still happen via `bower install ...`
