### PR TITLE
Ignore npm-debug.log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ heroku
 /views
 dist
 repositories
+
+npm-debug.log


### PR DESCRIPTION
Noticed the npm-debug.log file pop up in my git stage and figured it shouldn't be checked in.
