### PR TITLE
Remove API_HOST and API_PORT as they are not needed

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -6,8 +6,6 @@ angular.module('webdrivercssAdminpanelApp', [
     'ngRoute',
     'hljs'
 ])
-.constant('API_HOST','localhost')
-.constant('API_PORT',9000)
 .config(function($routeProvider, $locationProvider, hljsServiceProvider) {
 
     $routeProvider.when('/', {

--- a/app/scripts/directives/imageDiff.js
+++ b/app/scripts/directives/imageDiff.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('webdrivercssAdminpanelApp').directive('imagediff', function($http, API_HOST, API_PORT) {
+angular.module('webdrivercssAdminpanelApp').directive('imagediff', function($http) {
 
     var ImageDiff = function(id, width, height) {
 
@@ -182,7 +182,7 @@ angular.module('webdrivercssAdminpanelApp').directive('imagediff', function($htt
 
                 $http({
                     method: 'POST',
-                    url: 'http://' + API_HOST + ':' + API_PORT + '/api/repositories/confirm',
+                    url: '/api/repositories/confirm',
                     data: {
                         project: $scope.project,
                         file: $scope.diff.replace(/diff/,'new')

--- a/app/scripts/factories/ImageRepository.js
+++ b/app/scripts/factories/ImageRepository.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('webdrivercssAdminpanelApp').factory('ImageRepository', function(API_HOST, API_PORT, $q, $http) {
+angular.module('webdrivercssAdminpanelApp').factory('ImageRepository', function($q, $http) {
 
     var deferred  = $q.defer(),
         method = 'GET',


### PR DESCRIPTION
# What

When running this from a non-local machine, I get a URL error when trying to accept changes, due to the path being set to `http://localhost:9000`. 

Because this function will always be run from the URL of the API, this path isn't necessary (as far as I can tell), so I went ahead and all references of it.
# Testing
- Run the server from a different port or host than `localhost:9000`.
- Commit a set of breaking screenshot changes to the project
- Validate 'accept changes' functionality works.
# Notes
- This was the error I was getting:
  ![image](https://cloud.githubusercontent.com/assets/706039/9673005/75829e20-5265-11e5-872e-2b55715fbd89.png)
