### PR TITLE
Fix angular versions due to removed function is 1.6.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,20 +2,20 @@
   "name": "webdrivercss-adminpanel",
   "version": "0.0.0",
   "dependencies": {
-    "angular": ">=1.2.*",
+    "angular": ">=1.2.* <1.6.0",
     "json3": "~3.2.6",
     "es5-shim": "~2.1.0",
     "jquery": "~1.11.0",
     "bootstrap-sass-official": "~3.1.1",
-    "angular-resource": ">=1.2.*",
-    "angular-sanitize": ">=1.2.*",
-    "angular-route": ">=1.2.*",
+    "angular-resource": ">=1.2.*  <1.6.0",
+    "angular-sanitize": ">=1.2.*  <1.6.0",
+    "angular-route": ">=1.2.*  <1.6.0",
     "angular-highlightjs": "~0.3.0",
     "highlightjs": "~8.0.0"
   },
   "devDependencies": {
-    "angular-mocks": ">=1.2.*",
-    "angular-scenario": ">=1.2.*"
+    "angular-mocks": ">=1.2.*  <1.6.0",
+    "angular-scenario": ">=1.2.*  <1.6.0"
   },
   "testPath": "test/client/spec"
 }


### PR DESCRIPTION
According to [this](https://github.com/angular/angular.js/blob/master/CHANGELOG.md) in angular 1.6.0 success and error callbacks are removed. So we need to install lower angular versions